### PR TITLE
Feature/angular5

### DIFF
--- a/generators/app/templates/_.angular-cli.json
+++ b/generators/app/templates/_.angular-cli.json
@@ -43,13 +43,16 @@
   },
   "lint": [
     {
-      "project": "src/tsconfig.app.json"
+      "project": "src/tsconfig.app.json",
+      "exclude": "**/node_modules/**"
     },
     {
-      "project": "src/tsconfig.spec.json"
+      "project": "src/tsconfig.spec.json",
+      "exclude": "**/node_modules/**"
     },
     {
-      "project": "e2e/tsconfig.e2e.json"
+      "project": "e2e/tsconfig.e2e.json",
+      "exclude": "**/node_modules/**"
     }
   ],
   "test": {
@@ -60,8 +63,5 @@
   "defaults": {
     "styleExt": "scss",
     "component": {}
-  },
-  "warnings": {
-    "typescriptMismatch": false
   }
 }

--- a/generators/app/templates/_.gitignore
+++ b/generators/app/templates/_.gitignore
@@ -39,7 +39,7 @@ xcuserdata/
 # Misc
 /.sass-cache
 /connect.lock
-/coverage/*
+/coverage
 /libpeerconnection.log
 npm-debug.log
 testem.log

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -77,7 +77,7 @@
     "@types/jasminewd2": "^2.0.2",
     "@types/lodash": "^4.14.52",
     "@types/node": "^8.0.10",
-    "codelyzer": "~3.2.0",
+    "codelyzer": "~4.0.1",
     "hads": "^1.3.4",
     "htmlhint": "^0.9.13",
     "https-proxy-agent": "^2.0.0",
@@ -89,14 +89,14 @@
     "karma-coverage-istanbul-reporter": "^1.2.1",
     "karma-jasmine": "^1.1.0",
     "karma-junit-reporter": "^1.2.0",
-    "protractor": "~5.1.2",
-    "puppeteer": "^0.11.0",
-    "stylelint": "~8.1.0",
+    "protractor": "~5.2.0",
+    "puppeteer": "^0.12.0",
+    "stylelint": "~8.2.0",
     "stylelint-config-recommended-scss": "~2.0.0",
     "stylelint-config-standard": "~17.0.0",
     "stylelint-scss": "~2.1.0",
-    "ts-node": "^3.2.0",
-    "tslint": "~5.7.0",
+    "ts-node": "~3.3.0",
+    "tslint": "~5.8.0",
     "typescript": "~2.4.2"
   }
 }

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -55,7 +55,7 @@
 <% } else if (props.ui === 'material') { -%>
     "@angular/cdk": "^2.0.0-beta.12",
     "@angular/material": "^2.0.0-beta.12",
-    "@angular/flex-layout": "2.0.0-beta.9",
+    "@angular/flex-layout": "2.0.0-beta.11",
     "material-design-icons": "^3.0.1",
     "hammerjs": "^2.0.8",
 <% } -%>

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -46,7 +46,7 @@
     "@angular/service-worker": "^1.0.0-beta.16",
 <% } -%>
 <% if (props.ui === 'ionic') { -%>
-    "ionic-angular": "^3.5.3",
+    "ionic-angular": "^3.9.2",
     "ionicons": "^3.0.0",
 <% } else if (props.ui === 'bootstrap') { -%>
     "@ng-bootstrap/ng-bootstrap": "^1.0.0-beta.5",

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -55,7 +55,7 @@
 <% } else if (props.ui === 'material') { -%>
     "@angular/cdk": "^2.0.0-beta.12",
     "@angular/material": "^2.0.0-beta.12",
-    "@angular/flex-layout": "2.0.0-beta.11",
+    "@angular/flex-layout": "2.0.0-beta.10-4905443",
     "material-design-icons": "^3.0.1",
     "hammerjs": "^2.0.8",
 <% } -%>

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "ng": "ng",
     "build": "npm run env -s && ng build --prod",
-    "start": "ng serve --proxy-config proxy.conf.js",
+    "start": "ng serve --aot --proxy-config proxy.conf.js",
     "lint": "ng lint --type-check && stylelint \"src/**/*.scss\" --syntax scss && htmlhint \"src\" --config .htmlhintrc",
     "test": "ng test",
     "test:ci": "npm run lint -s && ng test --single-run --code-coverage",
@@ -26,15 +26,15 @@
     "generate": "ng generate"
   },
   "dependencies": {
-    "@angular/animations": "^4.2.6",
-    "@angular/common": "^4.2.6",
-    "@angular/compiler": "^4.2.6",
-    "@angular/core": "^4.2.6",
-    "@angular/forms": "^4.2.6",
-    "@angular/http": "^4.2.6",
-    "@angular/platform-browser": "^4.2.6",
-    "@angular/platform-browser-dynamic": "^4.2.6",
-    "@angular/router": "^4.2.6",
+    "@angular/animations": "^5.0.0",
+    "@angular/common": "^5.0.0",
+    "@angular/compiler": "^5.0.0",
+    "@angular/core": "^5.0.0",
+    "@angular/forms": "^5.0.0",
+    "@angular/http": "^5.0.0",
+    "@angular/platform-browser": "^5.0.0",
+    "@angular/platform-browser-dynamic": "^5.0.0",
+    "@angular/router": "^5.0.0",
     "@ngx-translate/core": "^8.0.0",
 <% if (props.target.includes('cordova')) { -%>
     "@ionic-native/core": "^4.0.0",
@@ -68,9 +68,9 @@
 <% if (props.target.includes('cordova')) { -%>
     "cordova": "^7.0.0",
 <% } -%>
-    "@angular/cli": "^1.4.2",
-    "@angular/compiler-cli": "^4.2.6",
-    "@angular/language-service": "^4.2.6",
+    "@angular/cli": "~1.5.0",
+    "@angular/compiler-cli": "^5.0.0",
+    "@angular/language-service": "^5.0.0",
     "@biesbjerg/ngx-translate-extract": "^2.3.1",
     "@ngx-rocket/scripts": "^1.0.4",
     "@types/jasmine": "^2.5.52",

--- a/generators/app/templates/src/polyfills.ts
+++ b/generators/app/templates/src/polyfills.ts
@@ -37,18 +37,22 @@ import 'core-js/es6/set';
 // IE10 and IE11 requires the following for NgClass support on SVG elements
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 
+// IE10 and IE11 requires the following for the Reflect API.
+// import 'core-js/es6/reflect';
+
+
 // Evergreen browsers require these.
-import 'core-js/es6/reflect';
+// Used for reflect-metadata in JIT. If you use AOT (and only Angular decorators), you can remove.
 import 'core-js/es7/reflect';
 
 
-// Required to support Web Animations `@angular/animation`.
+// Required to support Web Animations `@angular/platform-browser/animations`.
 // Needed for: All but Chrome, Firefox and Opera. http://caniuse.com/#feat=web-animation
 // import 'web-animations-js';  // Run `npm install --save web-animations-js`.
 
 
 // Zone JS is required by Angular itself.
-import 'zone.js/dist/zone';  // Included with Angular-CLI.
+import 'zone.js/dist/zone';  // Included with Angular CLI.
 
 
 /*

--- a/generators/app/templates/tsconfig.json
+++ b/generators/app/templates/tsconfig.json
@@ -17,5 +17,8 @@
       "es2017",
       "dom"
     ]
+  },
+  "angularCompilerOptions": {
+    "preserveWhitespaces": false
   }
 }

--- a/generators/app/templates/tslint.json
+++ b/generators/app/templates/tslint.json
@@ -15,7 +15,8 @@
     "forin": true,
     "import-blacklist": [
       true,
-      "rxjs"
+      "rxjs",
+      "rxjs/Rx"
     ],
     "import-spacing": true,
     "indent": [
@@ -33,7 +34,12 @@
     "member-ordering": [
       true,
       {
-        "order": "statics-first"
+        "order": [
+          "static-field",
+          "instance-field",
+          "static-method",
+          "instance-method"
+        ]
       }
     ],
     "no-arg": true,
@@ -139,9 +145,6 @@
     "use-life-cycle-interface": true,
     "use-pipe-transform-interface": true,
     "component-class-suffix": true,
-    "directive-class-suffix": true,
-    "no-access-missing-member": true,
-    "templates-use-public": true,
-    "invoke-injectable": true
+    "directive-class-suffix": true
   }
 }


### PR DESCRIPTION
Closes #164 

**Limitations**:
The reflect/es7 polyfills has to be kept only for the sake of of unit/e2e tests until this issue is resolved: https://github.com/angular/angular-cli/issues/6650

Also for reference, `@angular/service-worker` cannot be updated to `@5.0.0` because of https://github.com/angular/angular-cli/issues/8247 and we cannot migrate to the new `HttpClient` API because of https://github.com/angular/angular/issues/18155, so we are stuck with the deprecated `Http` service for now 😞 