### PR TITLE
Enable tsconfig strict mode and fix linked warnings

### DIFF
--- a/generators/app/templates/src/app/_app.component.ts
+++ b/generators/app/templates/src/app/_app.component.ts
@@ -121,6 +121,9 @@ export class AppComponent implements OnInit {
 <% if (props.ui === 'ionic') { -%>
   private updateNav(route: ActivatedRoute) {
     if (route.component === IonicApp) {
+      if (!route.firstChild) {
+        return;
+      }
       route = route.firstChild;
       if (!this.nav.getActive() || this.nav.getActive().component !== route.component) {
         this.nav.setRoot(route.component, route.params, { animate: true, direction: 'forward' });

--- a/generators/app/templates/src/app/core/authentication/__auth.authentication.service.mock.ts
+++ b/generators/app/templates/src/app/core/authentication/__auth.authentication.service.mock.ts
@@ -4,7 +4,7 @@ import { Credentials, LoginContext } from './authentication.service';
 
 export class MockAuthenticationService {
 
-  credentials: Credentials = {
+  credentials: Credentials | null = {
     username: 'test',
     token: '123'
   };

--- a/generators/app/templates/src/app/core/authentication/__auth.authentication.service.spec.ts
+++ b/generators/app/templates/src/app/core/authentication/__auth.authentication.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed, inject, fakeAsync, tick } from '@angular/core/testing';
 
-import { AuthenticationService } from './authentication.service';
+import { AuthenticationService, Credentials} from './authentication.service';
 
 const credentialsKey = 'credentials';
 
@@ -56,8 +56,8 @@ describe('AuthenticationService', () => {
         expect(authenticationService.isAuthenticated()).toBe(true);
         expect(authenticationService.credentials).toBeDefined();
         expect(authenticationService.credentials).not.toBeNull();
-        expect(authenticationService.credentials.token).toBeDefined();
-        expect(authenticationService.credentials.token).not.toBeNull();
+        expect((<Credentials>authenticationService.credentials).token).toBeDefined();
+        expect((<Credentials>authenticationService.credentials).token).not.toBeNull();
       });
     }));
 

--- a/generators/app/templates/src/app/core/authentication/__auth.authentication.service.ts
+++ b/generators/app/templates/src/app/core/authentication/__auth.authentication.service.ts
@@ -22,10 +22,13 @@ const credentialsKey = 'credentials';
 @Injectable()
 export class AuthenticationService {
 
-  private _credentials: Credentials;
+  private _credentials: Credentials | null;
 
   constructor() {
-    this._credentials = JSON.parse(sessionStorage.getItem(credentialsKey) || localStorage.getItem(credentialsKey));
+    const savedCredentials = sessionStorage.getItem(credentialsKey) || localStorage.getItem(credentialsKey);
+    if (savedCredentials) {
+      this._credentials = JSON.parse(savedCredentials);
+    }
   }
 
   /**
@@ -65,7 +68,7 @@ export class AuthenticationService {
    * Gets the user credentials.
    * @return {Credentials} The user credentials or null if the user is not authenticated.
    */
-  get credentials(): Credentials {
+  get credentials(): Credentials | null {
     return this._credentials;
   }
 

--- a/generators/app/templates/src/app/core/http/http-cache.service.spec.ts
+++ b/generators/app/templates/src/app/core/http/http-cache.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed, inject } from '@angular/core/testing';
 import { ResponseOptions } from '@angular/http';
 
-import { HttpCacheService } from './http-cache.service';
+import { HttpCacheService, HttpCacheEntry } from './http-cache.service';
 
 const cachePersistenceKey = 'httpCache';
 
@@ -57,8 +57,8 @@ describe('HttpCacheService', () => {
       httpCacheService.setCacheData('/hoho', null, response);
 
       // Assert
-      expect(httpCacheService.getHttpCacheEntry('/popo').lastUpdated).toBe(date);
-      expect(httpCacheService.getHttpCacheEntry('/hoho').lastUpdated).not.toBe(date);
+      expect((<HttpCacheEntry>httpCacheService.getHttpCacheEntry('/popo')).lastUpdated).toBe(date);
+      expect((<HttpCacheEntry>httpCacheService.getHttpCacheEntry('/hoho')).lastUpdated).not.toBe(date);
     });
   });
 
@@ -98,8 +98,9 @@ describe('HttpCacheService', () => {
       const entry = httpCacheService.getHttpCacheEntry('/hoho');
 
       // Assert
-      expect(entry.lastUpdated).toEqual(date);
-      expect(entry.data).toEqual(response);
+      expect(entry).not.toBeNull();
+      expect((<HttpCacheEntry>entry).lastUpdated).toEqual(date);
+      expect((<HttpCacheEntry>entry).data).toEqual(response);
     });
   });
 

--- a/generators/app/templates/src/app/core/http/http-cache.service.ts
+++ b/generators/app/templates/src/app/core/http/http-cache.service.ts
@@ -18,8 +18,8 @@ export interface HttpCacheEntry {
 @Injectable()
 export class HttpCacheService {
 
-  private cachedData: { [key: string]: HttpCacheEntry; } = {};
-  private storage: Storage = null;
+  private cachedData: { [key: string]: HttpCacheEntry | null; } = {};
+  private storage: Storage | null = null;
 
   constructor() {
     this.loadCacheData();
@@ -48,7 +48,7 @@ export class HttpCacheService {
    * @param {any=} params Optional request query parameters.
    * @return {?ResponseOptions} The cached data or null if no cached data exists for this request.
    */
-  getCacheData(url: string, params?: any): ResponseOptions {
+  getCacheData(url: string, params?: any): ResponseOptions | null {
     const cacheKey = this.getCacheKey(url, params);
     const cacheEntry = this.cachedData[cacheKey];
 
@@ -66,7 +66,7 @@ export class HttpCacheService {
    * @param {any=} params Optional request query parameters.
    * @return {?HttpCacheEntry} The cache entry or null if no cache entry exists for this request.
    */
-  getHttpCacheEntry(url: string, params?: any): HttpCacheEntry {
+  getHttpCacheEntry(url: string, params?: any): HttpCacheEntry | null {
     return this.cachedData[this.getCacheKey(url, params)] || null;
   }
 
@@ -77,7 +77,7 @@ export class HttpCacheService {
    */
   clearCache(url: string, params?: any): void {
     const cacheKey = this.getCacheKey(url, params);
-    this.cachedData[cacheKey] = undefined;
+    this.cachedData[cacheKey] = null;
     log.debug('Cache cleared for key: "' + cacheKey + '"');
     this.saveCacheData();
   }
@@ -105,7 +105,7 @@ export class HttpCacheService {
    * @param {'local'|'session'=} persistence How the cache should be persisted, it can be either local or session
    *   storage, or if no value is provided it will be only in-memory (default).
    */
-  setPersistence(persistence?: 'local'|'session') {
+  setPersistence(persistence?: 'local' | 'session') {
     this.cleanCache();
     this.storage = persistence === 'local' || persistence === 'session' ? window[persistence + 'Storage'] : null;
     this.loadCacheData();

--- a/generators/app/templates/src/app/core/http/http.service.ts
+++ b/generators/app/templates/src/app/core/http/http.service.ts
@@ -34,7 +34,7 @@ export class HttpService extends Http {
    * You can customize this method with your own extended behavior.
    */
   request(request: string|Request, options?: RequestOptionsArgs): Observable<Response> {
-    options = options || {};
+    const requestOptions = options || {};
     let url: string;
 
     if (typeof request === 'string') {
@@ -45,18 +45,19 @@ export class HttpService extends Http {
       request.url = environment.serverUrl + url;
     }
 
-    if (!options.cache) {
+    if (!requestOptions.cache) {
       // Do not use cache
-      return this.httpRequest(request, options);
+      return this.httpRequest(request, requestOptions);
     } else {
       return new Observable((subscriber: Subscriber<Response>) => {
-        const cachedData = options.cache === HttpCachePolicy.Update ? null : this.httpCacheService.getCacheData(url);
+        const cachedData = requestOptions.cache === HttpCachePolicy.Update ?
+        null : this.httpCacheService.getCacheData(url);
         if (cachedData !== null) {
           // Create new response to avoid side-effects
           subscriber.next(new Response(cachedData));
           subscriber.complete();
         } else {
-          this.httpRequest(request, options).subscribe(
+          this.httpRequest(request, requestOptions).subscribe(
             (response: Response) => {
               // Store the serializable version of the response
               this.httpCacheService.setCacheData(url, null, new ResponseOptions({
@@ -69,7 +70,7 @@ export class HttpService extends Http {
               }));
               subscriber.next(response);
             },
-            (error) => subscriber.error(error),
+            (error: any) => subscriber.error(error),
             () => subscriber.complete()
           );
         }
@@ -118,7 +119,7 @@ export class HttpService extends Http {
   private httpRequest(request: string|Request, options: RequestOptionsArgs): Observable<Response> {
     let req = super.request(request, options);
     if (!options.skipErrorHandler) {
-      req = req.pipe(catchError(error => this.errorHandler(error)));
+      req = req.pipe(catchError((error: any) => this.errorHandler(error)));
     }
     return req;
   }

--- a/generators/app/templates/src/app/core/i18n.service.spec.ts
+++ b/generators/app/templates/src/app/core/i18n.service.spec.ts
@@ -9,7 +9,7 @@ const supportedLanguages = ['eo', 'en-US', 'fr-FR'];
 
 class MockTranslateService {
 
-  currentLang: string = null;
+  currentLang: string;
   onLangChange = new Subject();
 
   use(language: string) {

--- a/generators/app/templates/src/app/core/i18n.service.ts
+++ b/generators/app/templates/src/app/core/i18n.service.ts
@@ -40,7 +40,7 @@ export class I18nService {
   init(defaultLanguage: string, supportedLanguages: string[]) {
     this.defaultLanguage = defaultLanguage;
     this.supportedLanguages = supportedLanguages;
-    this.language = null;
+    this.language = '';
 
     this.translateService.onLangChange
       .subscribe((event: LangChangeEvent) => { localStorage.setItem(languageKey, event.lang); });
@@ -59,7 +59,7 @@ export class I18nService {
     // If no exact match is found, search without the region
     if (language && !isSupportedLanguage) {
       language = language.split('-')[0];
-      language = this.supportedLanguages.find(supportedLanguage => supportedLanguage.startsWith(language));
+      language = this.supportedLanguages.find(supportedLanguage => supportedLanguage.startsWith(language)) || '';
       isSupportedLanguage = Boolean(language);
     }
 

--- a/generators/app/templates/src/app/core/shell/__ionic._shell.component.ts
+++ b/generators/app/templates/src/app/core/shell/__ionic._shell.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Router, NavigationEnd, ActivatedRoute } from '@angular/router';
-import { ActionSheetController, AlertController, Platform } from 'ionic-angular';
+import { ActionSheetController, AlertController, Platform, ActionSheetOptions } from 'ionic-angular';
+import { ActionSheetButton } from 'ionic-angular/components/action-sheet/action-sheet-options';
 import { TranslateService } from '@ngx-translate/core';
 import { filter } from 'rxjs/operators';
 
@@ -41,17 +42,18 @@ export class ShellComponent implements OnInit {
 
 <% if (props.auth) { -%>
   showProfileActions() {
-    const actionSheet = this.actionSheetController.create({ title: this.username });
-    const buttons = [
+    const actionSheetOptions: ActionSheetOptions = { title: this.username || undefined };    
+    const actionSheet = this.actionSheetController.create(actionSheetOptions);
+    const buttons: ActionSheetButton[] = [
       {
         text: this.translateService.instant('Logout'),
-        icon: this.platform.is('ios') ? null : 'log-out',
+        icon: this.platform.is('ios') ? undefined : 'log-out',
         role: 'destructive',
         handler: () => this.logout()
       },
       {
         text: this.translateService.instant('Change language'),
-        icon: this.platform.is('ios') ? null : 'globe',
+        icon: this.platform.is('ios') ? undefined : 'globe',
         handler: () => {
           // Wait for action sheet dismiss animation to finish, see "Dismissing And Async Navigation" section in:
           // http://ionicframework.com/docs/api/components/action-sheet/ActionSheetController/#advanced
@@ -61,7 +63,7 @@ export class ShellComponent implements OnInit {
       },
       {
         text: this.translateService.instant('Cancel'),
-        icon: this.platform.is('ios') ? null : 'close',
+        icon: this.platform.is('ios') ? undefined : 'close',
         role: 'cancel'
       }
     ];
@@ -75,7 +77,7 @@ export class ShellComponent implements OnInit {
     actionSheet.present();
   }
 
-  get username(): string {
+  get username(): string | null {
     const credentials = this.authenticationService.credentials;
     return credentials ? credentials.username : null;
   }
@@ -123,9 +125,12 @@ export class ShellComponent implements OnInit {
   }
 
   private updateNav(route: ActivatedRoute) {
+    if (!route || !route.firstChild) {
+      return;
+    }
     // First component should always be IonicApp
     route = route.firstChild;
-    if (route && route.component === ShellComponent) {
+    if (route && route.component === ShellComponent && route.firstChild) {
       route = route.firstChild;
       this.navRoot = <Component>route.component;
     }

--- a/generators/app/templates/src/app/core/shell/__ionic._shell.component.ts
+++ b/generators/app/templates/src/app/core/shell/__ionic._shell.component.ts
@@ -38,11 +38,11 @@ export class ShellComponent implements OnInit {
     this.subscription = this.router.events
       .pipe(filter(event => event instanceof NavigationEnd))
       .subscribe(() => this.updateNav(this.activatedRoute));
-  }
+    }
 
 <% if (props.auth) { -%>
   showProfileActions() {
-    const actionSheetOptions: ActionSheetOptions = { title: this.username || undefined };    
+    const actionSheetOptions: ActionSheetOptions = { title: this.username || undefined };
     const actionSheet = this.actionSheetController.create(actionSheetOptions);
     const buttons: ActionSheetButton[] = [
       {

--- a/generators/app/templates/src/app/core/shell/__material._shell.component.ts
+++ b/generators/app/templates/src/app/core/shell/__material._shell.component.ts
@@ -35,7 +35,7 @@ export class ShellComponent implements OnInit {
       .subscribe(() => this.router.navigate(['/login'], { replaceUrl: true }));
   }
 
-  get username(): string {
+  get username(): string | null {
     const credentials = this.authenticationService.credentials;
     return credentials ? credentials.username : null;
   }

--- a/generators/app/templates/src/app/core/shell/header/__bootstrap._header.component.ts
+++ b/generators/app/templates/src/app/core/shell/header/__bootstrap._header.component.ts
@@ -51,7 +51,7 @@ export class HeaderComponent implements OnInit {
   }
 
 <% if (props.auth) { -%>
-  get username(): string {
+  get username(): string | null {
     const credentials = this.authenticationService.credentials;
     return credentials ? credentials.username : null;
   }

--- a/generators/app/templates/src/app/login/__auth._login.component.ts
+++ b/generators/app/templates/src/app/login/__auth._login.component.ts
@@ -21,7 +21,7 @@ const log = new Logger('Login');
 export class LoginComponent implements OnInit {
 
   version: string = environment.version;
-  error: string = null;
+  error: string;
   loginForm: FormGroup;
 <% if (props.ui !== 'ionic') { -%>
   isLoading = false;

--- a/generators/app/templates/src/app/shared/loader/_loader.component.ts
+++ b/generators/app/templates/src/app/shared/loader/_loader.component.ts
@@ -11,7 +11,7 @@ export class LoaderComponent implements OnInit {
 <% if (props.ui === 'material') { -%>
   @Input() size = 1;
 <% } -%>
-  @Input() message: string = null;
+  @Input() message: string;
 
   constructor() { }
 

--- a/generators/app/templates/tsconfig.json
+++ b/generators/app/templates/tsconfig.json
@@ -16,7 +16,8 @@
     "lib": [
       "es2017",
       "dom"
-    ]
+    ],
+    "strict": true
   },
   "angularCompilerOptions": {
     "preserveWhitespaces": false

--- a/generators/app/templates/tsconfig.json
+++ b/generators/app/templates/tsconfig.json
@@ -16,8 +16,7 @@
     "lib": [
       "es2017",
       "dom"
-    ],
-    "strict": true
+    ]
   },
   "angularCompilerOptions": {
     "preserveWhitespaces": false


### PR DESCRIPTION
⚠️  WORK IN PROGRESS ⚠️ 

---

As discussed in #163 there is no more warning link to strict mode in Angular sources.

So I set `strict:true` in tsconfig of generated project and fix all warnings that pops out (mainly `strictNullChecks`).

---

⚠️  For now `ionic-angular` module is not compatible with `strictNullChecks` (Low priority issue on ionic repo: https://github.com/ionic-team/ionic/issues/10646) so ionic-generated project won't compile. 

A workaround will be to only use strict mode for Bootstrap and Angular Material projects, @sinedied what do you think about this?