### PR TITLE
ionic: invalid view to insert when route to lazy loading page

### DIFF
--- a/generators/app/templates/src/app/core/shell/__ionic._shell.component.ts
+++ b/generators/app/templates/src/app/core/shell/__ionic._shell.component.ts
@@ -135,14 +135,8 @@ export class ShellComponent implements OnInit {
 
       // Fixed the bug#19420 : route.component is undefined if module is lazy
       // See: https://github.com/angular/angular/issues/19420
-      let child = route;
-      while (child) {
-        if (child.firstChild) {
-          child = child.firstChild;
-          route = child;
-        } else {
-          child = null;
-        }
+      while (route.firstChild) {
+        route = route.firstChild;
       }
       // Fixed #19420 end
 

--- a/generators/app/templates/src/app/core/shell/__ionic._shell.component.ts
+++ b/generators/app/templates/src/app/core/shell/__ionic._shell.component.ts
@@ -132,6 +132,20 @@ export class ShellComponent implements OnInit {
     route = route.firstChild;
     if (route && route.component === ShellComponent && route.firstChild) {
       route = route.firstChild;
+
+      //fixed the bug#19420 : route.component is undefined if module is lazy
+      //https://github.com/angular/angular/issues/19420
+      let child = route;
+      while (child) {
+        if (child.firstChild) {
+          child = child.firstChild;
+          route = child;
+        } else {
+          child = null;
+        }
+      }
+      //fixed #19420 end
+
       this.navRoot = <Component>route.component;
     }
   }

--- a/generators/app/templates/src/app/core/shell/__ionic._shell.component.ts
+++ b/generators/app/templates/src/app/core/shell/__ionic._shell.component.ts
@@ -133,8 +133,8 @@ export class ShellComponent implements OnInit {
     if (route && route.component === ShellComponent && route.firstChild) {
       route = route.firstChild;
 
-      //fixed the bug#19420 : route.component is undefined if module is lazy
-      //https://github.com/angular/angular/issues/19420
+      // Fixed the bug#19420 : route.component is undefined if module is lazy
+      // See: https://github.com/angular/angular/issues/19420
       let child = route;
       while (child) {
         if (child.firstChild) {

--- a/generators/app/templates/src/app/core/shell/__ionic._shell.component.ts
+++ b/generators/app/templates/src/app/core/shell/__ionic._shell.component.ts
@@ -144,7 +144,7 @@ export class ShellComponent implements OnInit {
           child = null;
         }
       }
-      //fixed #19420 end
+      // Fixed #19420 end
 
       this.navRoot = <Component>route.component;
     }


### PR DESCRIPTION
Reason: Router's ActivatedRoute `component` is undefined if module is lazy 

FYI: there is still another bug to prevent AboutComponent loading.
It should be ok if use `<router-outlet>` instead of `<ion-nav>`.