### PR TITLE
Update to FontAwesome 5

### DIFF
--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -38,9 +38,6 @@
     "@angular/platform-browser": "^5.2.5",
     "@angular/platform-browser-dynamic": "^5.2.5",
     "@angular/router": "^5.2.5",
-<% if (props.ui === 'bootstrap') { -%>
-    "@fortawesome/fontawesome-free-webfonts": "^1.0.3",
-<% } -%>
     "@ngx-translate/core": "^9.0.1",
 <% if (props.target.includes('cordova')) { -%>
     "@ionic-native/core": "^4.5.3",
@@ -65,6 +62,7 @@
 <% } else if (props.ui === 'bootstrap') { -%>
     "@ng-bootstrap/ng-bootstrap": "^1.0.0",
     "bootstrap": "4.0.0",
+    "@fortawesome/fontawesome-free-webfonts": "^1.0.3",
 <% } else if (props.ui === 'material') { -%>
     "@angular/cdk": "^5.2.1",
     "@angular/material": "^5.2.1",

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -38,6 +38,9 @@
     "@angular/platform-browser": "^5.2.5",
     "@angular/platform-browser-dynamic": "^5.2.5",
     "@angular/router": "^5.2.5",
+<% if (props.ui === 'bootstrap') { -%>
+    "@fortawesome/fontawesome-free-webfonts": "^1.0.3",
+<% } -%>
     "@ngx-translate/core": "^9.0.1",
 <% if (props.target.includes('cordova')) { -%>
     "@ionic-native/core": "^4.5.3",
@@ -62,7 +65,6 @@
 <% } else if (props.ui === 'bootstrap') { -%>
     "@ng-bootstrap/ng-bootstrap": "^1.0.0",
     "bootstrap": "4.0.0",
-    "font-awesome": "^4.7.0",
 <% } else if (props.ui === 'material') { -%>
     "@angular/cdk": "^5.2.1",
     "@angular/material": "^5.2.1",

--- a/generators/app/templates/src/_main.scss
+++ b/generators/app/templates/src/_main.scss
@@ -259,7 +259,10 @@
 /* stylelint-enable */
 <% } else if (props.ui === 'bootstrap') { -%>
 @import "~bootstrap/scss/bootstrap";
-@import "~font-awesome/scss/font-awesome.scss";
+@import "~@fortawesome/fontawesome-free-webfonts/scss/fontawesome.scss";
+@import "~@fortawesome/fontawesome-free-webfonts/scss/fa-brands.scss";
+@import "~@fortawesome/fontawesome-free-webfonts/scss/fa-regular.scss";
+@import "~@fortawesome/fontawesome-free-webfonts/scss/fa-solid.scss";
 <% } else if (props.ui === 'material') { -%>
 @import "~material-design-icons/iconfont/material-icons.css";
 

--- a/generators/app/templates/src/app/about/__bootstrap.about.component.html
+++ b/generators/app/templates/src/app/about/__bootstrap.about.component.html
@@ -4,7 +4,7 @@
       <span translate>APP_NAME</span>
     </h1>
     <p>
-      <i class="fa fa-bookmark-o"></i> <span translate>Version</span> {{version}}
+      <i class="far fa-bookmark"></i> <span translate>Version</span> {{version}}
     </p>
   </div>
 </div>

--- a/generators/app/templates/src/app/core/shell/header/__bootstrap._header.component.html
+++ b/generators/app/templates/src/app/core/shell/header/__bootstrap._header.component.html
@@ -8,11 +8,11 @@
     <div id="navbar-menu" class="collapse navbar-collapse float-xs-none" [ngbCollapse]="menuHidden">
       <div class="navbar-nav">
         <a class="nav-item nav-link text-uppercase" routerLink="/home" routerLinkActive="active">
-          <i class="fa fa-home"></i>
+          <i class="fas fa-home"></i>
           <span translate>Home</span>
         </a>
         <a class="nav-item nav-link text-uppercase" routerLink="/about" routerLinkActive="active">
-          <i class="fa fa-question-circle"></i>
+          <i class="fas fa-question-circle"></i>
           <span translate>About</span>
         </a>
       </div>
@@ -28,7 +28,7 @@
 <% if (props.auth) { -%>
         <div class="nav-item" ngbDropdown placement="bottom-right">
           <a id="user-dropdown" class="nav-link" ngbDropdownToggle>
-            <i class="fa fa-user-circle"></i>
+            <i class="fas fa-user-circle"></i>
           </a>
           <div ngbDropdownMenu aria-labelledby="user-dropdown">
             <h6 class="dropdown-header">

--- a/generators/app/templates/src/app/core/shell/header/__material-simple._header.component.html
+++ b/generators/app/templates/src/app/core/shell/header/__material-simple._header.component.html
@@ -8,11 +8,11 @@
   <div fxHide.lt-md>
     <a class="brand" href="https://github.com/ngx-rocket" translate>APP_NAME</a>
     <button mat-button routerLink="/home" routerLinkActive="active">
-      <i class="fa fa-home"></i>
+      <mat-icon>home</mat-icon>
       <span translate>Home</span>
     </button>
     <button mat-button routerLink="/about" routerLinkActive="active">
-      <i class="fa fa-question-circle"></i>
+      <mat-icon>info</mat-icon>
       <span translate>About</span>
     </button>
   </div>

--- a/generators/app/templates/src/app/login/__auth+bootstrap.login.component.html
+++ b/generators/app/templates/src/app/login/__auth+bootstrap.login.component.html
@@ -18,7 +18,7 @@
       <div class="card col-md-6 mt-3 mx-auto">
         <div class="card-body">
           <h4 class="card-title text-center">
-            <i class="fa fa-3x fa-user-circle-o text-muted"></i>
+            <i class="far fa-3x fa-user-circle text-muted"></i>
           </h4>
           <form (ngSubmit)="login()" [formGroup]="loginForm" novalidate>
             <div class="alert alert-danger" [hidden]="!error || isLoading" translate>
@@ -51,7 +51,7 @@
               </div>
             </div>
             <button class="btn btn-primary w-100" type="submit" [disabled]="loginForm.invalid || isLoading">
-              <i class="fa fa-cog fa-spin" [hidden]="!isLoading"></i>
+              <i class="fas fa-cog fa-spin" [hidden]="!isLoading"></i>
               <span translate>Login</span>
             </button>
           </form>

--- a/generators/app/templates/src/app/shared/loader/__bootstrap.loader.component.html
+++ b/generators/app/templates/src/app/shared/loader/__bootstrap.loader.component.html
@@ -1,4 +1,4 @@
 <div [hidden]="!isLoading" class="text-xs-center">
-  <i class="fa fa-cog fa-spin fa-3x"></i> <span>{{message}}</span>
+  <i class="fas fa-cog fa-spin fa-3x"></i> <span>{{message}}</span>
 </div>
 

--- a/generators/app/templates/src/theme/__bootstrap.theme-variables.scss
+++ b/generators/app/templates/src/theme/__bootstrap.theme-variables.scss
@@ -3,7 +3,7 @@
  */
 
 // Set Font Awesome font path
-$fa-font-path: "~/font-awesome/fonts";
+$fa-font-path: "~@fortawesome/fontawesome-free-webfonts/webfonts";
 
 // ---------------------------------------------------------------------------
 // Bootstrap variables


### PR DESCRIPTION
With this new version FontAwesome move to a new npm scoped repo `@fortawesome/fontawesome-XXX`, split icons in multiple fonts (brand, solid, outline) and rename some of [them](https://fontawesome.com/how-to-use/upgrading-from-4). I also fix some minor copy-paste errors about FontAwesome icons being in Material template.

BTW, it's still in "beta" but the team is working on an Angular component for Font Awesome 5: https://github.com/FortAwesome/angular-fontawesome 