### PR TITLE
fix json format for manifest file

### DIFF
--- a/generators/app/templates/src/__pwa._manifest.json
+++ b/generators/app/templates/src/__pwa._manifest.json
@@ -10,5 +10,5 @@
     "src": "assets/ngx-rocket-logo.png",
     "sizes": "512x512",
     "type": "image/png"
-  }],
+  }]
 }


### PR DESCRIPTION
Cordova browser fails to run with error `Error: Unexpected token } in JSON at position 269` 
You moved 
`"background_color": "#488aff",
  "theme_color": "#488aff"`
to the top of the file and forget to remove the comma