### PR TITLE
Update _index.html, fix cordova routing bug

### DIFF
--- a/generators/app/templates/src/_index.html
+++ b/generators/app/templates/src/_index.html
@@ -54,6 +54,10 @@
 <%   } else { -%>
     if (!/^http/.test(location.protocol)) {
 <%   } -%>
+      /**
+       * https://github.com/angular/angular/issues/22509
+       * Prevent cordova.js 5.2.4+ routing bug
+      **/
       window.addEventListener = function () {
           EventTarget.prototype.addEventListener.apply(this, arguments);
       };

--- a/generators/app/templates/src/_index.html
+++ b/generators/app/templates/src/_index.html
@@ -54,6 +54,18 @@
 <%   } else { -%>
     if (!/^http/.test(location.protocol)) {
 <%   } -%>
+      window.addEventListener = function () {
+          EventTarget.prototype.addEventListener.apply(this, arguments);
+      };
+      window.removeEventListener = function () {
+          EventTarget.prototype.removeEventListener.apply(this, arguments);
+      };
+      document.addEventListener = function () {
+          EventTarget.prototype.addEventListener.apply(this, arguments);
+      };
+      document.removeEventListener = function () {
+          EventTarget.prototype.removeEventListener.apply(this, arguments);
+      };
       document.write('<script src="cordova.js"><\/script>');
     }
   </script>


### PR DESCRIPTION
Regarding this issue https://github.com/angular/angular/issues/22509
There is a bug on mobile with cordova when navigating back to the previous page. The router-outlet is appending rather than replacing the component, it is very annoying. 
It seems that there isn't any solution now other than reseting the addEventListener and removeEventListener functions.