### PR TITLE
Fix typo in i18n docs

### DIFF
--- a/generators/app/templates/docs/i18n.md
+++ b/generators/app/templates/docs/i18n.md
@@ -28,7 +28,7 @@ translateService.get('My page title').subscribe((res: string) => { title = res; 
 
 ## Extracting strings to translate
 
-Once you are ready to translate your app, just run `npm translations:extract`.
+Once you are ready to translate your app, just run `npm run translations:extract`.
 It will create a `template.json` file in the `src/translations` folder.
 
 You can then use any text or code editor to generate the `.json` files for each of your supported languages, and put


### PR DESCRIPTION
`npm translations:extract` -> `npm run translations:extract`