### PR TITLE
Commented the importance of module import order

### DIFF
--- a/generators/app/templates/src/app/_app.module.ts
+++ b/generators/app/templates/src/app/_app.module.ts
@@ -87,7 +87,7 @@ import { AppRoutingModule } from './app-routing.module';
 <% } else if (props.angulartics ) { -%>
     Angulartics2Module.forRoot([]),
 <% } -%>
-    AppRoutingModule
+    AppRoutingModule // must be imported as the last module as it contains the fallback route
   ],
   declarations: [AppComponent],
   providers: [


### PR DESCRIPTION
Added comment about the importance of importing `AppRoutingModule` as the last module.
Resolves #384 