### PR TITLE
Removal of deprecated keyboard

### DIFF
--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -50,7 +50,6 @@
     "@ngx-translate/core": "^10.0.1",
 <% if (props.target.includes('cordova')) { -%>
     "@ionic-native/core": "^4.5.3",
-    "@ionic-native/keyboard": "^4.5.3",
     "@ionic-native/splash-screen": "^4.5.3",
     "@ionic-native/status-bar": "^4.5.3",
     "cordova-android": "^7.0.0",
@@ -58,7 +57,7 @@
     "cordova-ios": "^4.5.4",
     "cordova-plugin-device": "^2.0.1",
     "cordova-plugin-ionic-webview": "^2.0.0",
-    "cordova-plugin-ionic-keyboard": "^2.0.5",
+    "cordova-plugin-ionic-keyboard": "^2.1.2",
     "cordova-plugin-splashscreen": "^5.0.2",
     "cordova-plugin-statusbar": "^2.4.1",
     "cordova-plugin-whitelist": "^1.3.3",

--- a/generators/app/templates/src/app/_app.component.spec.ts
+++ b/generators/app/templates/src/app/_app.component.spec.ts
@@ -5,7 +5,6 @@ import { TranslateModule } from '@ngx-translate/core';
 import { IonicModule } from 'ionic-angular';
 <% } -%>
 <% if (props.target.includes('cordova')) { -%>
-import { Keyboard } from '@ionic-native/keyboard';
 import { StatusBar } from '@ionic-native/status-bar';
 import { SplashScreen } from '@ionic-native/splash-screen';
 <% } -%>
@@ -34,7 +33,6 @@ describe('AppComponent', () => {
       declarations: [AppComponent],
 <% if (props.target.includes('cordova')) { -%>
       providers: [
-        Keyboard,
         StatusBar,
         SplashScreen
       ]

--- a/generators/app/templates/src/app/_app.component.ts
+++ b/generators/app/templates/src/app/_app.component.ts
@@ -18,7 +18,6 @@ import { IonicApp, Nav } from 'ionic-angular';
 <%   } -%>
 <% } -%>
 <% if (props.target.includes('cordova')) { -%>
-import { Keyboard } from '@ionic-native/keyboard';
 import { StatusBar } from '@ionic-native/status-bar';
 import { SplashScreen } from '@ionic-native/splash-screen';
 <% } -%>
@@ -52,7 +51,6 @@ export class AppComponent implements OnInit {
 <%   } else { -%>
               private zone: NgZone,
 <%   } -%>
-              private keyboard: Keyboard,
               private statusBar: StatusBar,
               private splashScreen: SplashScreen,
 <% } -%>
@@ -119,7 +117,7 @@ export class AppComponent implements OnInit {
 
   private onCordovaReady() {
     if (window['cordova']) {
-      this.keyboard.hideKeyboardAccessoryBar(true);
+      window['Keyboard'].hideFormAccessoryBar(true);
 <% if (props.ui === 'ionic') { -%>
       this.statusBar.styleLightContent();
 <% } else { -%>

--- a/generators/app/templates/src/app/_app.module.ts
+++ b/generators/app/templates/src/app/_app.module.ts
@@ -22,7 +22,6 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { IonicApp, IonicErrorHandler, IonicModule } from 'ionic-angular';
 <% } -%>
 <% if (props.target.includes('cordova')) { -%>
-import { Keyboard } from '@ionic-native/keyboard';
 import { StatusBar } from '@ionic-native/status-bar';
 import { SplashScreen } from '@ionic-native/splash-screen';
 <% } -%>
@@ -107,7 +106,6 @@ import { AppRoutingModule } from './app-routing.module';
 <%   } -%>
 <% } -%>
 <% if (props.target.includes('cordova')) { -%>
-    Keyboard,
     StatusBar,
     SplashScreen
 <% } -%>


### PR DESCRIPTION
To be honest, I can't understand why this is breaking tests on master NOW - it seems to coincide with a recent release of cordova-plugin-ionic-keyboard, but the commits don't seem like they would cause it.  Maybe another related package?

Anyway, it's been deprecated, so I figured might as well backport this.  If you folks don't want this, another possibility is to try to mess with package.json versions.
