### PR TITLE
Added untilDestroyed operator to properly clean up subscriptions on component destroy

### DIFF
--- a/generators/app/templates/src/app/_app.component.ts
+++ b/generators/app/templates/src/app/_app.component.ts
@@ -109,6 +109,10 @@ export class AppComponent implements OnInit, OnDestroy {
     }, false);
 <% } -%>
   }
+
+  ngOnDestroy() {
+    this.i18nService.destroy();
+  }
 <% if (props.target.includes('cordova')) { -%>
 
   private onCordovaReady() {
@@ -123,9 +127,5 @@ export class AppComponent implements OnInit, OnDestroy {
     }
   }
 <% } -%>
-
-  ngOnDestroy() {
-    this.i18nService.destroy();
-  }
 
 }

--- a/generators/app/templates/src/app/_app.component.ts
+++ b/generators/app/templates/src/app/_app.component.ts
@@ -1,9 +1,9 @@
 <% if (props.ui === 'ionic') { -%>
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
 <% } else if (props.target.includes('cordova')) { -%>
-import { Component, OnInit, NgZone } from '@angular/core';
+import { Component, OnInit, OnDestroy, NgZone } from '@angular/core';
 <% } else { -%>
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 <% } -%>
 import { Router, NavigationEnd, ActivatedRoute } from '@angular/router';
 import { Title } from '@angular/platform-browser';
@@ -24,7 +24,7 @@ import { Angulartics2GoogleAnalytics } from 'angulartics2/ga';
 <% } -%>
 
 import { environment } from '@env/environment';
-import { Logger, I18nService } from '@app/core';
+import { Logger, I18nService, untilDestroyed } from '@app/core';
 
 <% if (props.target.includes('cordova')) { -%>
 
@@ -36,7 +36,7 @@ const log = new Logger('App');
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })
-export class AppComponent implements OnInit {
+export class AppComponent implements OnInit, OnDestroy {
 
   constructor(private router: Router,
               private activatedRoute: ActivatedRoute,
@@ -86,7 +86,8 @@ export class AppComponent implements OnInit {
           return route;
         }),
         filter(route => route.outlet === 'primary'),
-        mergeMap(route => route.data)
+        mergeMap(route => route.data),
+        untilDestroyed(this)
       )
       .subscribe(event => {
         const title = event['title'];
@@ -122,5 +123,9 @@ export class AppComponent implements OnInit {
     }
   }
 <% } -%>
+
+  ngOnDestroy() {
+    this.i18nService.destroy();
+  }
 
 }

--- a/generators/app/templates/src/app/_app.module.ts
+++ b/generators/app/templates/src/app/_app.module.ts
@@ -61,7 +61,7 @@ import { AppRoutingModule } from './app-routing.module';
     BrowserAnimationsModule,
     MaterialModule,
 <% } else if (props.ui === 'bootstrap') { -%>
-    NgbModule.forRoot(),
+    NgbModule,
 <% } else if (props.ui === 'ionic') { -%>
     IonicModule.forRoot(),
 <% } -%>

--- a/generators/app/templates/src/app/core/_index.ts
+++ b/generators/app/templates/src/app/core/_index.ts
@@ -12,3 +12,4 @@ export * from './http/cache.interceptor';
 export * from './http/error-handler.interceptor';
 export * from './route-reusable-strategy';
 export * from './logger.service';
+export * from './until-destroyed';

--- a/generators/app/templates/src/app/core/i18n.service.ts
+++ b/generators/app/templates/src/app/core/i18n.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { TranslateService, LangChangeEvent } from '@ngx-translate/core';
+import { Subscription } from 'rxjs';
 import { includes } from 'lodash';
 
 import { Logger } from './logger.service';
@@ -25,6 +26,8 @@ export class I18nService {
   defaultLanguage: string;
   supportedLanguages: string[];
 
+  private langChangeSubscription: Subscription;
+
   constructor(private translateService: TranslateService) {
     // Embed languages to avoid extra HTTP requests
     translateService.setTranslation('en-US', enUS);
@@ -42,8 +45,16 @@ export class I18nService {
     this.supportedLanguages = supportedLanguages;
     this.language = '';
 
-    this.translateService.onLangChange
+    // Warning: this subscription will always be alive for the app's lifetime
+    this.langChangeSubscription = this.translateService.onLangChange
       .subscribe((event: LangChangeEvent) => { localStorage.setItem(languageKey, event.lang); });
+  }
+
+  /**
+   * Cleans up language change subscription.
+   */
+  destroy() {
+    this.langChangeSubscription.unsubscribe();
   }
 
   /**

--- a/generators/app/templates/src/app/core/until-destroyed.spec.ts
+++ b/generators/app/templates/src/app/core/until-destroyed.spec.ts
@@ -129,10 +129,6 @@ describe('untilDestroyed', () => {
     // Arrange
     const spy = createObserver();
 
-    class LoginComponent {
-      dummy = new Subject().pipe(untilDestroyed(this)).subscribe(spy);
-    }
-
     class A implements OnDestroy {
       ngOnDestroy() {}
     }

--- a/generators/app/templates/src/app/core/until-destroyed.spec.ts
+++ b/generators/app/templates/src/app/core/until-destroyed.spec.ts
@@ -1,3 +1,4 @@
+import { OnInit, OnDestroy } from '@angular/core';
 import { Subject, Subscription } from 'rxjs';
 
 import { untilDestroyed } from './until-destroyed';
@@ -6,7 +7,7 @@ function createObserver() {
   return {
     next: jasmine.createSpy(),
     error: jasmine.createSpy(),
-    complete: jasmine.createSpy(),
+    complete: jasmine.createSpy()
   };
 }
 
@@ -16,13 +17,13 @@ describe('untilDestroyed', () => {
     const spy = createObserver();
     const spy2 = createObserver();
 
-    class Test {
+    class Test implements OnDestroy {
       obs: Subscription;
 
       ngOnDestroy() {}
 
-      subscribe(spy: any) {
-        this.obs = new Subject().pipe(untilDestroyed(this)).subscribe(spy);
+      subscribe(cb: any) {
+        this.obs = new Subject().pipe(untilDestroyed(this)).subscribe(cb);
       }
     }
 
@@ -46,7 +47,7 @@ describe('untilDestroyed', () => {
     const spy2 = createObserver();
     const spy3 = createObserver();
 
-    class Test {
+    class Test implements OnDestroy {
       obs = new Subject().pipe(untilDestroyed(this)).subscribe(spy);
       obs2 = new Subject().pipe(untilDestroyed(this)).subscribe(spy2);
       obs3 = new Subject().pipe(untilDestroyed(this)).subscribe(spy3);
@@ -87,7 +88,7 @@ describe('untilDestroyed', () => {
     const spy2 = createObserver();
     const spy3 = createObserver();
 
-    class LoginComponent {
+    class LoginComponent implements OnInit, OnDestroy {
       dummy = new Subject().pipe(untilDestroyed(this)).subscribe(spy);
 
       constructor() {
@@ -132,7 +133,7 @@ describe('untilDestroyed', () => {
       dummy = new Subject().pipe(untilDestroyed(this)).subscribe(spy);
     }
 
-    class A {
+    class A implements OnDestroy {
       ngOnDestroy() {}
     }
 
@@ -148,13 +149,16 @@ describe('untilDestroyed', () => {
     // Arrange
     const spy = createObserver();
 
-    class Parent {
+    class Parent implements OnDestroy {
       ngOnDestroy() {}
     }
 
     class Child extends Parent {
-      constructor() { super();}
       obs = new Subject().pipe(untilDestroyed(this)).subscribe(spy);
+
+      constructor() {
+        super();
+      }
     }
 
     // Assert

--- a/generators/app/templates/src/app/core/until-destroyed.spec.ts
+++ b/generators/app/templates/src/app/core/until-destroyed.spec.ts
@@ -1,0 +1,165 @@
+import { Subject, Subscription } from 'rxjs';
+
+import { untilDestroyed } from './until-destroyed';
+
+function createObserver() {
+  return {
+    next: jasmine.createSpy(),
+    error: jasmine.createSpy(),
+    complete: jasmine.createSpy(),
+  };
+}
+
+describe('untilDestroyed', () => {
+  it('should not destroy other instances', () => {
+    // Arrange
+    const spy = createObserver();
+    const spy2 = createObserver();
+
+    class Test {
+      obs: Subscription;
+
+      ngOnDestroy() {}
+
+      subscribe(spy: any) {
+        this.obs = new Subject().pipe(untilDestroyed(this)).subscribe(spy);
+      }
+    }
+
+    // Act
+    const component1 = new Test();
+    const component2 = new Test();
+    component1.subscribe(spy);
+    component2.subscribe(spy2);
+    component1.ngOnDestroy();
+
+    // Assert
+    expect(spy.complete).toHaveBeenCalledTimes(1);
+    expect(spy2.complete).not.toHaveBeenCalled();
+    component2.ngOnDestroy();
+    expect(spy2.complete).toHaveBeenCalledTimes(1);
+  });
+
+  it('should work with multiple observables', () => {
+    // Arrange
+    const spy = createObserver();
+    const spy2 = createObserver();
+    const spy3 = createObserver();
+
+    class Test {
+      obs = new Subject().pipe(untilDestroyed(this)).subscribe(spy);
+      obs2 = new Subject().pipe(untilDestroyed(this)).subscribe(spy2);
+      obs3 = new Subject().pipe(untilDestroyed(this)).subscribe(spy3);
+
+      ngOnDestroy() {}
+    }
+
+    // Act
+    const instance = new Test();
+    instance.ngOnDestroy();
+
+    // Assert
+    expect(spy.complete).toHaveBeenCalledTimes(1);
+    expect(spy2.complete).toHaveBeenCalledTimes(1);
+    expect(spy3.complete).toHaveBeenCalledTimes(1);
+  });
+
+  it('should work with classes that are not components', () => {
+    // Arrange
+    const spy = createObserver();
+
+    // Act
+    class Test {
+      obs = new Subject().pipe(untilDestroyed(this, 'destroy')).subscribe(spy);
+
+      destroy() {}
+    }
+
+    // Assert
+    const instance = new Test();
+    instance.destroy();
+    expect(spy.complete).toHaveBeenCalledTimes(1);
+  });
+
+  it('should unsubscribe from anywhere', () => {
+    // Arrange
+    const spy = createObserver();
+    const spy2 = createObserver();
+    const spy3 = createObserver();
+
+    class LoginComponent {
+      dummy = new Subject().pipe(untilDestroyed(this)).subscribe(spy);
+
+      constructor() {
+        new Subject().pipe(untilDestroyed(this)).subscribe(spy2);
+      }
+
+      ngOnInit() {
+        new Subject().pipe(untilDestroyed(this)).subscribe(spy3);
+      }
+
+      ngOnDestroy() {}
+    }
+
+    // Act
+    const instance = new LoginComponent();
+    instance.ngOnInit();
+    instance.ngOnDestroy();
+
+    // Assert
+    expect(spy.complete).toHaveBeenCalledTimes(1);
+    expect(spy2.complete).toHaveBeenCalledTimes(1);
+    expect(spy3.complete).toHaveBeenCalledTimes(1);
+  });
+
+  it('should throw when destroy method doesnt exist', () => {
+    // Arrange
+    const spy = createObserver();
+
+    class LoginComponent {
+      dummy = new Subject().pipe(untilDestroyed(this)).subscribe(spy);
+    }
+
+    // Assert
+    expect(() => new LoginComponent()).toThrow();
+  });
+
+  it('should not throw when destroy method is implemented on super class', () => {
+    // Arrange
+    const spy = createObserver();
+
+    class LoginComponent {
+      dummy = new Subject().pipe(untilDestroyed(this)).subscribe(spy);
+    }
+
+    class A {
+      ngOnDestroy() {}
+    }
+
+    class B extends A {
+      dummy = new Subject().pipe(untilDestroyed(this)).subscribe(spy);
+    }
+
+    // Assert
+    expect(() => new B()).not.toThrow();
+  });
+
+  it('should work with subclass', () => {
+    // Arrange
+    const spy = createObserver();
+
+    class Parent {
+      ngOnDestroy() {}
+    }
+
+    class Child extends Parent {
+      constructor() { super();}
+      obs = new Subject().pipe(untilDestroyed(this)).subscribe(spy);
+    }
+
+    // Assert
+    const instance = new Child();
+    instance.ngOnDestroy();
+    expect(spy.complete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/generators/app/templates/src/app/core/until-destroyed.ts
+++ b/generators/app/templates/src/app/core/until-destroyed.ts
@@ -1,0 +1,58 @@
+import { Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+
+const untilDestroyedSymbol = Symbol('untilDestroyed');
+const isFunction = (value: any) => typeof value === 'function';
+
+/**
+ * RxJS operator that unsubscribe from observables on destory.
+ * Code forked from https://github.com/NetanelBasal/ngx-take-until-destroy
+ *
+ * IMPORTANT: Add the `untilDestroyed` operator as the last one to prevent leaks with intermediate observables in the
+ * operator chain.
+ *
+ * @param {Object} instance The parent Angular component or object instance.
+ * @param {String=} destroyMethodName The method to hook on (default: 'ngOnDestroy').
+ * @example
+ * ```
+ * import { untilDestroyed } from '@app/core';
+ *
+ * @Component({
+ * selector: 'app-example',
+ *   templateUrl: './example.component.html'
+ * })
+ * export class ExampleComponent implements OnInit, OnDestroy {
+ *   ngOnInit() {
+ *     interval(1000)
+ *       .pipe(untilDestroyed(this))
+ *       .subscribe(val => console.log(val));
+ *   }
+ *
+ *   // This method must be present, even if empty.
+ *   ngOnDestroy() {
+ *     // To protect you, an error will be thrown if it doesn't exist.
+ *   }
+ * }
+ * ```
+ */
+export function untilDestroyed(instance: Object, destroyMethodName = 'ngOnDestroy') {
+  return <T>(source: Observable<T>) => {
+    const originalDestroy = instance[destroyMethodName];
+
+    if (!isFunction(originalDestroy)) {
+      throw new Error(`${instance.constructor.name} is using untilDestroyed but doesn't implement ${destroyMethodName}`);
+    }
+
+    if (!instance[untilDestroyedSymbol]) {
+      instance[untilDestroyedSymbol] = new Subject();
+
+      instance[destroyMethodName] = function () {
+        isFunction(originalDestroy) && originalDestroy.apply(this, arguments);
+        instance[untilDestroyedSymbol].next();
+        instance[untilDestroyedSymbol].complete();
+      };
+    }
+
+    return source.pipe(takeUntil<T>(instance[untilDestroyedSymbol]));
+  }
+}

--- a/generators/app/templates/src/app/login/__auth._login.component.spec.ts
+++ b/generators/app/templates/src/app/login/__auth._login.component.spec.ts
@@ -31,7 +31,7 @@ describe('LoginComponent', () => {
         IonicModule.forRoot(),
         FormsModule,
 <% } else if (props.ui === 'bootstrap') { -%>
-        NgbModule.forRoot(),
+        NgbModule,
 <% } else if (props.ui === 'material') { -%>
         BrowserAnimationsModule,
         FlexLayoutModule,

--- a/generators/app/templates/src/app/shell/__material-simple.shell.component.ts
+++ b/generators/app/templates/src/app/shell/__material-simple.shell.component.ts
@@ -3,7 +3,7 @@ import { MediaChange, ObservableMedia } from '@angular/flex-layout';
 import { MatSidenav } from '@angular/material';
 import { filter } from 'rxjs/operators';
 
-import { untilDestroyed } from "@app/core";
+import { untilDestroyed } from '@app/core';
 
 @Component({
   selector: 'app-shell',

--- a/generators/app/templates/src/app/shell/__material-simple.shell.component.ts
+++ b/generators/app/templates/src/app/shell/__material-simple.shell.component.ts
@@ -1,14 +1,16 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
 import { MediaChange, ObservableMedia } from '@angular/flex-layout';
 import { MatSidenav } from '@angular/material';
 import { filter } from 'rxjs/operators';
+
+import { untilDestroyed } from "@app/core";
 
 @Component({
   selector: 'app-shell',
   templateUrl: './shell.component.html',
   styleUrls: ['./shell.component.scss']
 })
-export class ShellComponent implements OnInit {
+export class ShellComponent implements OnInit, OnDestroy {
 
   @ViewChild('sidenav') sidenav: MatSidenav;
 
@@ -17,8 +19,15 @@ export class ShellComponent implements OnInit {
   ngOnInit() {
     // Automatically close side menu on screens > sm breakpoint
     this.media.asObservable()
-      .pipe(filter((change: MediaChange) => (change.mqAlias !== 'xs' && change.mqAlias !== 'sm')))
+      .pipe(
+        filter((change: MediaChange) => (change.mqAlias !== 'xs' && change.mqAlias !== 'sm')),
+        untilDestroyed(this)
+      )
       .subscribe(() => this.sidenav.close());
+  }
+
+  ngOnDestroy() {
+    // Needed for automatic unsubscribe with untilDestroyed
   }
 
 }

--- a/generators/app/templates/src/app/shell/_shell.component.spec.ts
+++ b/generators/app/templates/src/app/shell/_shell.component.spec.ts
@@ -48,7 +48,7 @@ describe('ShellComponent', () => {
         SettingsModule,
 <%   } -%>
 <% } else if (props.ui === 'bootstrap') { -%>
-        NgbModule.forRoot(),
+        NgbModule,
 <% } else if (props.ui === 'material') { -%>
         BrowserAnimationsModule,
         FlexLayoutModule,

--- a/generators/app/templates/src/app/shell/header/__bootstrap._header.component.spec.ts
+++ b/generators/app/templates/src/app/shell/header/__bootstrap._header.component.spec.ts
@@ -18,7 +18,7 @@ describe('HeaderComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         RouterTestingModule,
-        NgbModule.forRoot(),
+        NgbModule,
         TranslateModule.forRoot()
       ],
       declarations: [HeaderComponent],


### PR DESCRIPTION
This new operator is forked from https://github.com/NetanelBasal/ngx-take-until-destroy/blob/master/src/take-until-destroy.ts and helps resolving dangling subscriptions that causes memory leaks and dangerous behaviour.

We already had an issue with the shell fixed by this PR (and this was much worse priori to Ionic 4 migration!) and also with the app, but the latter was a minor issue as apart from exceptional use cases (micro frontend, angular elements...) the app component will never be recycled. Still, it's not fixed to propagates best practices and avoid further mistakes.