### PR TITLE
Added ionic webview details for CORS-all platforms

### DIFF
--- a/generators/app/templates/docs/__cordova.cordova.md
+++ b/generators/app/templates/docs/__cordova.cordova.md
@@ -239,6 +239,8 @@ npm run cordova -- plugin <add|remove> cordova-plugin-ionic-webview
 
 On a new project, external domain navigation is disabled but loading resources from any domain is enabled by default.
 
+Although XHRs to all domains are enabled in the default whitelist configuration, it doesn't apply when using the ionic-webview cordova plugin versions 2+.  Therefore, if your app is a full-stack app or it needs to access any APIs, you'll need to either be sure the CORS headers allow the origin localhost:8080, or remove the ionic-webview plugin.  You can find more details about this in the [ionic webview documentation](https://beta.ionicframework.com/docs/building/webview/#cors).  Note that this applies to both ios and android builds.
+
 Before building for production, you should consider restricting domain access to improve your app security.
 You can find documentation on this regard in the
 [Cordova whitelist guide](https://cordova.apache.org/docs/en/latest/guide/appdev/whitelist/index.html).


### PR DESCRIPTION
Just adding some clarity that ionic webview 2+ nerfs the whitelist, and so CORS is indeed needed, even for android. Much of the internet will say otherwise, so it's a bit of a gotcha that I think is worth mentioning.
