### PR TITLE
DRAFT for discussion - Update ionic to rc.0 and their new tabs

### DIFF
--- a/generators/app/prompts.js
+++ b/generators/app/prompts.js
@@ -112,7 +112,6 @@ module.exports = [
     name: 'lazy',
     message: 'Do you want lazy loading?',
     default: false,
-    when: props => props.ui !== 'ionic'
   },
   {
     type: 'confirm',

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -48,15 +48,15 @@
     "generate": "ng generate"
   },
   "dependencies": {
-    "@angular/animations": "^7.0.0",
-    "@angular/common": "^7.0.0",
-    "@angular/compiler": "^7.0.0",
-    "@angular/core": "^7.0.0",
-    "@angular/forms": "^7.0.0",
-    "@angular/http": "^7.0.0",
-    "@angular/platform-browser": "^7.0.0",
-    "@angular/platform-browser-dynamic": "^7.0.0",
-    "@angular/router": "^7.0.0",
+    "@angular/animations": "^7.1.4",
+    "@angular/common": "^7.1.4",
+    "@angular/compiler": "^7.1.4",
+    "@angular/core": "^7.1.4",
+    "@angular/forms": "^7.1.4",
+    "@angular/http": "^7.1.4",
+    "@angular/platform-browser": "^7.1.4",
+    "@angular/platform-browser-dynamic": "^7.1.4",
+    "@angular/router": "^7.1.4",
     "@ngx-translate/core": "^10.0.1",
 <% if (props.target.includes('cordova')) { -%>
     "@ionic-native/core": "5.0.0-beta.21",
@@ -73,10 +73,10 @@
     "cordova-plugin-whitelist": "^1.3.3",
 <% } -%>
 <% if (props.pwa) { -%>
-    "@angular/service-worker": "^7.0.0",
+    "@angular/service-worker": "^7.1.4",
 <% } -%>
 <% if (props.ui === 'ionic') { -%>
-    "@ionic/angular": "4.0.0-beta.16",
+    "@ionic/angular": "4.0.0-rc.0",
 <% } else if (props.ui === 'bootstrap') { -%>
     "@ng-bootstrap/ng-bootstrap": "^3.3.0",
     "bootstrap": "^4.1.1",
@@ -89,7 +89,7 @@
     "hammerjs": "^2.0.8",
 <% } -%>
 <% if (props.angulartics) { -%>
-    "angulartics2": "^6.0.0",
+    "angulartics2": "^7.0.0",
 <% } -%>
     "core-js": "^2.5.6",
     "lodash": "^4.17.10",
@@ -106,7 +106,7 @@
     "@angular/cli": "~7.0.2",
     "@angular/compiler-cli": "^7.0.0",
     "@angular/language-service": "^7.0.0",
-    "@angular-devkit/build-angular": "^0.10.2",
+    "@angular-devkit/build-angular": "^0.11.4",
     "@biesbjerg/ngx-translate-extract": "^2.3.4",
     "@ngx-rocket/scripts": "^3.0.0",
     "@types/jasmine": "^2.8.7",

--- a/generators/app/templates/src/app/_app-routing.module.ts
+++ b/generators/app/templates/src/app/_app-routing.module.ts
@@ -13,7 +13,11 @@ const routes: Routes = [
   ]),
 <% } -%>
   // Fallback when no prior route is matched
+<% if (props.ui === 'ionic' && props.layout === 'tabs') { -%>
+  { path: '**', redirectTo: '/tabs/home', pathMatch: 'full' }
+<% } else { -%>
   { path: '**', redirectTo: '', pathMatch: 'full' }
+<% } -%>
 ];
 
 @NgModule({

--- a/generators/app/templates/src/app/shell/__ionic-tabs.shell.component.html
+++ b/generators/app/templates/src/app/shell/__ionic-tabs.shell.component.html
@@ -1,7 +1,6 @@
 <ion-tabs #navTabs useRouter="true">
-  <ion-router-outlet></ion-router-outlet>
   <ion-tab-bar slot="bottom" [selectedTab]="selectedTabName$ | async">
-    <ion-tab-button *ngFor="let t of tabs; index as tabIndex" [tab]="t.name" show="true" [href]="t.route">
+    <ion-tab-button *ngFor="let t of tabs; index as tabIndex" [tab]="t.name" show="true">
       <ion-icon [name]="t.icon"></ion-icon>
       <ion-label>{{ t.title | translate }}</ion-label>
     </ion-tab-button>

--- a/generators/app/templates/src/app/shell/_shell.service.ts
+++ b/generators/app/templates/src/app/shell/_shell.service.ts
@@ -17,7 +17,11 @@ export class Shell {
    */
   static childRoutes(routes: Routes): Route {
     return {
+<% if (props.ui === 'ionic' && props.layout === 'tabs') { -%>
+      path: 'tabs',
+<% } else { -%>
       path: '',
+<% } -%>
       component: ShellComponent,
       children: routes,
 <% if (props.auth) { -%>


### PR DESCRIPTION
Well, the good news is that lazy loading now works \o/. And the sidemenu routing is still stable.

But here's the bad news - shenanigans are back and ionic's tabs are opinionated as heck. After a tab is selected, it stays alive forever even if you navigate away from it. This is by their design and I couldn't find a workaround.

I can see this seen as a feature for some use cases, but what this means is that if we want to do initialization properly, someone using the ionic tabs version should use a mix of ionic lifecycle hooks and angular ones, and I'm guessing this is contrary to the goals of this project. Our tabs starter doesn't really need any initialization, so maybe we can just leave it to whoever generates a tabs project to deal with that hassle if it affects their use case? I don't know - what do you think?

