### PR TITLE
Allow forcing generator options from addon (close #444)

### DIFF
--- a/generators/addon/templates/generators/app/_index.js
+++ b/generators/addon/templates/generators/app/_index.js
@@ -16,11 +16,15 @@ class <%= props.className %>Generator extends Generator {
     // Setting version allows Yeoman to notify the user of updates
     this.version = pkg.version;
     this.log(`Using ${chalk.cyan('<%= props.projectName %>')} ${chalk.green(this.version)}`);
+
+    // Allow to pre-set any props in another add-on generator
+    // If don't want your generator prompts to be overridable, remove this line.
+    Object.assign(this.props, this.sharedProps);
   }
 
   beforeWriting() {
-    // Augment this generator's properties with shared properties so it can be
-    // used in templates
+    // Augment this generator's properties with shared properties after prompts,
+    // so it can be used in templates
     Object.assign(this.props, this.sharedProps);
   }
 }

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -78,6 +78,9 @@ class NgxGenerator extends Generator {
   }
 
   async prompting() {
+    // Allow to pre-set any props in an add-on generator
+    Object.assign(this.props, this.sharedProps);
+
     await super.prompting();
     this.props.mobile = this.props.mobile || [];
     this.shareProps(this.props);


### PR DESCRIPTION
Also add this possibility by default for new addons.
This could have been done in @ngx-rocket/core, but I prefer to ive the
choice to opt-out of this behavior.