### PR TITLE
Add notranslate tag to index.html

### DIFF
--- a/generators/app/prompts.js
+++ b/generators/app/prompts.js
@@ -35,6 +35,13 @@ module.exports = [
     when: props => props.target && props.target.includes('web')
   },
   {
+    type: 'confirm',
+    name: 'gmt',
+    message: 'Do you want add meta (content="notranslate") so Google Chrome doesn\'t offer to translate it?',
+    default: false,
+    when: props => props.target && props.target.includes('web')
+  },
+  {
     type: 'checkbox',
     name: 'mobile',
     message: 'Which mobile platform do you want to support?',

--- a/generators/app/prompts.js
+++ b/generators/app/prompts.js
@@ -37,7 +37,7 @@ module.exports = [
   {
     type: 'confirm',
     name: 'gmt',
-    message: 'Do you want add meta (content="notranslate") so Google Chrome doesn\'t offer to translate it?',
+    message: 'Do you want add meta (content="notranslate") so Google Chrome does not offer to translate it?',
     default: false,
     when: props => props.target && props.target.includes('web')
   },

--- a/generators/app/templates/src/_index.html
+++ b/generators/app/templates/src/_index.html
@@ -14,6 +14,9 @@
 <% } else { -%>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <% } -%>
+<% if (props.target.includes('web') && props.gmt) { -%>
+  <meta name="google" content="notranslate">
+<% } -%>
 <% if (props.target.includes('cordova') || props.pwa) { -%>
   <meta name="theme-color" content="#4e8ef7"/>
 <% } -%>


### PR DESCRIPTION
Hi.
Let me explain the reason for this PR.

When I create a new application, in the classic way (Angular CLI) or with ngx-rocket, one of the first configurations that I make is to disable the translation offered by Google Chrome.
![notranslate01](https://user-images.githubusercontent.com/7057691/79074598-9e1cc380-7ced-11ea-83df-ecc359cf9768.png)
Nowadays "automatic" translations are quite precise but they are not perfect, and this is the reason why automatic translation should be disabled.

I added a simple prompt option that ask to include this tag in the index.html (default to NO)
![notranslate](https://user-images.githubusercontent.com/7057691/79074672-07043b80-7cee-11ea-878e-5057c008bbf8.png)

If the condition apply then the tag will be added
![notranslate3](https://user-images.githubusercontent.com/7057691/79074780-94e02680-7cee-11ea-8003-05184d0d1327.png)

Cordially
Fabio