### PR TITLE
fix: german translation home and cancel spelling

### DIFF
--- a/generators/app/templates/src/translations/__de-DE._de-DE.json
+++ b/generators/app/templates/src/translations/__de-DE._de-DE.json
@@ -2,9 +2,9 @@
   "APP_NAME": "<%= props.appName %>",
   "About": "Über",
   "Hello world !": "Hallo welt !",
-  "Home": "Hause",
+  "Home": "Startseite",
 <% if (props.ui === 'ionic') { -%>
-  "Cancel": "Abbruch",
+  "Cancel": "Abbrechen",
   "Change language": "Sprache wechseln",
   "Language": "Sprache",
   "Ok": "Ok",


### PR DESCRIPTION
in german it is a better wording to call the homepage "startseite".