### PR TITLE
feat: Local language name for bootstrap and Material (language selector component)

### DIFF
--- a/generators/app/templates/src/app/i18n/__bootstrap.language-selector.component.html
+++ b/generators/app/templates/src/app/i18n/__bootstrap.language-selector.component.html
@@ -1,15 +1,15 @@
 <div [ngClass]="{ 'nav-item': inNavbar }" ngbDropdown>
   <a *ngIf="inNavbar; else button" id="language-dropdown" class="nav-link" ngbDropdownToggle>
-    {{currentLanguage | translate}}
+    {{getLanguageName(currentLanguage)}}
   </a>
   <ng-template #button>
     <button id="language-dropdown" class="btn btn-sm btn-secondary" ngbDropdownToggle>
-      {{currentLanguage}}
+      {{getLanguageName(currentLanguage)}}
     </button>
   </ng-template>
   <div ngbDropdownMenu aria-labelledby="language-dropdown" [ngClass]="menuClass">
     <button class="dropdown-item" *ngFor="let language of languages" (click)="setLanguage(language)">
-      {{language | translate}}
+      {{getLanguageName(language)}}
     </button>
   </div>
 </div>

--- a/generators/app/templates/src/app/i18n/__material.language-selector.component.html
+++ b/generators/app/templates/src/app/i18n/__material.language-selector.component.html
@@ -3,11 +3,11 @@
 </button>
 <ng-template #text>
   <button mat-raised-button color="primary" [matMenuTriggerFor]="languageMenu">
-    {{currentLanguage}}
+    {{getLanguageName(currentLanguage)}}
   </button>
 </ng-template>
 <mat-menu #languageMenu="matMenu">
   <button mat-menu-item *ngFor="let language of languages" (click)="setLanguage(language)">
-    {{language}}
+    {{getLanguageName(language)}}
   </button>
 </mat-menu>

--- a/generators/app/templates/src/app/i18n/_language-selector.component.ts
+++ b/generators/app/templates/src/app/i18n/_language-selector.component.ts
@@ -7,6 +7,19 @@ import { AlertController } from '@ionic/angular';
 
 import { I18nService } from './i18n.service';
 
+<% if (props.ui === 'bootstrap' || props.ui === 'material') { -%>
+// Local language name
+enum ELanguages {
+  'de-DE' = 'Deutsche',
+  'en-US' = 'English',
+  'es-ES' = 'Español', // Castellano
+  'fr-FR' = 'Française',
+  'it-IT' = 'Italiano',
+  'pt-BR' = 'pt-BR', // Português do Brasil
+  'zh-CN' = 'zh-CN' // 简体中文
+}
+<% } -%>
+
 @Component({
   selector: 'app-language-selector',
   templateUrl: './language-selector.component.html',
@@ -46,6 +59,14 @@ export class LanguageSelectorComponent implements OnInit {
   get languages(): string[] {
     return this.i18nService.supportedLanguages;
   }
+
+<% if (props.ui === 'bootstrap' || props.ui === 'material') { -%>
+  public getLanguageName(languageName: string): string {
+    const langName: string = ELanguages[ languageName ];
+    return langName;
+  }
+<% } -%>
+
 <% if (props.ui === 'ionic') { -%>
 
   async changeLanguage() {


### PR DESCRIPTION
Hi all

I just added a enum with the language code and is corresponding language name
I made it only for Bootstrap and Material.

Probably there is a better way to add it to the enum... a for loop like 
```
<% for (let lang of props.languages) { -%>
```
instead of fill the enum with all the cases as I did...

```
<% if (props.ui === 'bootstrap' || props.ui === 'material') { -%>
// Local language name
enum ELanguages {
  'de-DE' = 'Deutsche',
  'en-US' = 'English',
  'es-ES' = 'Español', // Castellano
  'fr-FR' = 'Française',
  'it-IT' = 'Italiano',
  'pt-BR' = 'pt-BR', // Português do Brasil
  'zh-CN' = 'zh-CN' // 简体中文
}
<% } -%>
```


![Screenshot_05](https://user-images.githubusercontent.com/7057691/109082366-2472a600-7704-11eb-84a6-5489984afc48.png)

Cordially
Fabio