### PR TITLE
refactor: jest.config paths generation at runtime

### DIFF
--- a/generators/app/templates/__tools-jest._jest.config.js
+++ b/generators/app/templates/__tools-jest._jest.config.js
@@ -2,7 +2,7 @@
 const { pathsToModuleNameMapper } = require('ts-jest/utils');
 // In the following statement, replace `./tsconfig` with the path to your `tsconfig` file
 // which contains the path mapping (ie the `compilerOptions.paths` option):
-const { compilerOptions } = require('./tsconfig');
+const { compilerOptions } = require('./tsconfig.json');
 
 module.exports = {
   preset: 'jest-preset-angular',

--- a/generators/app/templates/__tools-jest._jest.config.js
+++ b/generators/app/templates/__tools-jest._jest.config.js
@@ -1,17 +1,15 @@
 // https://github.com/thymikee/jest-preset-angular#brief-explanation-of-config
+const { pathsToModuleNameMapper } = require('ts-jest/utils');
+// In the following statement, replace `./tsconfig` with the path to your `tsconfig` file
+// which contains the path mapping (ie the `compilerOptions.paths` option):
+const { compilerOptions } = require('./tsconfig');
+
 module.exports = {
   preset: 'jest-preset-angular',
   roots: ['src'],
   coverageDirectory: 'reports',
   setupFilesAfterEnv: ['<rootDir>/src/setup-jest.ts'],
-  moduleNameMapper: {
-    '@app/(.*)': '<rootDir>/src/app/$1',
-<% if (props.usePrefix) { -%>
-    '@shared': ['<rootDir>/src/app/@shared'],
-    '@shared/(.*)': ['<rootDir>/src/app/@shared/$1'],
-<% } -%>
-    '@env': '<rootDir>/src/environments/environment'
-  },
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, { prefix: '<rootDir>/' }),
   globals: {
     'ts-jest': {
       allowSyntheticDefaultImports: true,

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -124,7 +124,8 @@
 <% } -%>
     "rxjs": "^6.6.3",
     "tslib": "^2.2.0",
-    "zone.js": "~0.11.4"
+    "zone.js": "~0.11.4",
+    "ts-jest": "^27.0.5"
   },
   "devDependencies": {
 <% if (props.target.includes('cordova')) { -%>

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -185,6 +185,7 @@
 <% } -%>
 <% if (props.tools.includes('jest')) { -%>
     "jest": "^27.0.6",
+    "ts-jest": "^27.0.5",
 <% } else { -%>
     "karma": "~6.3.0",
     "karma-chrome-launcher": "~3.1.0",
@@ -212,9 +213,8 @@
     "stylelint-config-standard": "~22.0.0",
     "stylelint-scss": "~3.20.1",
     "ts-node": "^10.1.0",
-    "typescript": "~4.3.2",
+    "typescript": "~4.3.2"
 <% if (props.tools.includes('prettier')) { -%>
-    "ts-jest": "^27.0.5"
   },
   "prettier": {
     "singleQuote": true,

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -124,8 +124,7 @@
 <% } -%>
     "rxjs": "^6.6.3",
     "tslib": "^2.2.0",
-    "zone.js": "~0.11.4",
-    "ts-jest": "^27.0.5"
+    "zone.js": "~0.11.4"
   },
   "devDependencies": {
 <% if (props.target.includes('cordova')) { -%>
@@ -213,8 +212,9 @@
     "stylelint-config-standard": "~22.0.0",
     "stylelint-scss": "~3.20.1",
     "ts-node": "^10.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.3.2",
 <% if (props.tools.includes('prettier')) { -%>
+    "ts-jest": "^27.0.5"
   },
   "prettier": {
     "singleQuote": true,

--- a/generators/app/templates/_tsconfig.json
+++ b/generators/app/templates/_tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
   "compileOnSave": false,
   "compilerOptions": {

--- a/generators/app/templates/_tsconfig.json
+++ b/generators/app/templates/_tsconfig.json
@@ -43,10 +43,10 @@
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,
     "strictInjectionParameters": true,
-    "preserveWhitespaces": true,
 <% if (props.strict) { -%>
     "strictInputAccessModifiers": true,
-    "strictTemplates": true
+    "strictTemplates": true,
 <% } -%>
+    "preserveWhitespaces": true
   }
 }


### PR DESCRIPTION
By using a simple function provided by ts-jest/utils, we can remove the need to manually update the jest.config every time a new path is added to tsconfig.json