### PR TITLE
fix: do not close sidenave when undefined

### DIFF
--- a/generators/app/templates/src/app/shell/__material-simple.shell.component.ts
+++ b/generators/app/templates/src/app/shell/__material-simple.shell.component.ts
@@ -25,7 +25,7 @@ export class ShellComponent implements OnInit {
         filter(({ matches }) => !matches),
         untilDestroyed(this)
       )
-      .subscribe(() => this.sidenav.close());
+      .subscribe(() => this.sidenav?.close());
   }
 
 }


### PR DESCRIPTION
The sidenave is only available in the reduced version of the nav bar. When loading the page without the sidenav child, an error occurs : "shell.component.ts:27 ERROR TypeError: Cannot read properties of undefined (reading 'close')".